### PR TITLE
New Setting: Preserve manual User assignments.

### DIFF
--- a/classes/domain/autogroup_set.php
+++ b/classes/domain/autogroup_set.php
@@ -100,6 +100,7 @@ class autogroup_set extends domain
         //this has to be done first to prevent event handler getting in the way
         $db->delete_records('local_autogroup_set', array('id'=>$this->id));
         $db->delete_records('local_autogroup_roles', array('setid'=>$this->id));
+        $db->delete_records('local_autogroup_manual', array('groupid'=>$this->id));
 
         if($cleanupgroups){
             foreach($this->groups as $k => $group){

--- a/classes/domain/group.php
+++ b/classes/domain/group.php
@@ -90,6 +90,16 @@ class group extends domain
      * @param int $userid
      */
     public function ensure_user_is_not_member($userid){
+
+        // Do not allow autogroup to remove this User if they were manually assigned to group.
+        $pluginconfig = get_config('local_autogroup');
+        if($pluginconfig->preservemanual) {
+            global $DB;
+            if($DB->record_exists('local_autogroup_manual', array('userid' => $userid, 'groupid' => $this->id))) {
+                return;
+            }
+        }
+
         foreach($this->members as $member){
             if ($member == $userid) {
                 \groups_remove_member($this->as_object(), $userid);

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+	"name": "lambdasolutions/moodle-local_autogroup",
+	"description": "Autogroup (Local Plugin)",
+	"type": "moodle-local",
+	"extra": {
+		"installer-name": "autogroup"
+	},
+	"require": {
+		"composer/installers": "~1.0"
+	}
+}

--- a/db/install.xml
+++ b/db/install.xml
@@ -29,5 +29,15 @@
                 <KEY NAME="roleid" TYPE="foreign" FIELDS="roleid" REFTABLE="role" REFFIELDS="id"/>
             </KEYS>
         </TABLE>
+        <TABLE NAME="local_autogroup_manual" COMMENT="Tracks manually assigned Users to autogroup groups">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="groupid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Group ID of this record."/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="User ID of this record." />
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
     </TABLES>
 </XMLDB>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -19,5 +19,27 @@ function xmldb_local_autogroup_upgrade($oldversion) {
         // savepoint reached.
         upgrade_plugin_savepoint(true, 2016062201, 'local', 'autogroup');
     }
+
+    if ($oldversion < 2018102300) {
+        // Define table local_autogroup_manual to be created.
+        $table = new xmldb_table('local_autogroup_manual');
+
+        // Adding fields to table local_autogroup_manual.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('groupid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+
+        // Adding keys to table local_autogroup_manual.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+
+        // Conditionally launch create table for local_autogroup_manual.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Autogroup savepoint reached.
+        upgrade_plugin_savepoint(true, 2018102300, 'local', 'autogroup');
+    }
+
     return true;
 }

--- a/lang/en/local_autogroup.php
+++ b/lang/en/local_autogroup.php
@@ -55,6 +55,7 @@ $string['create'] = 'Create new group set:';
 // Admin Settings
 $string['addtonewcourses'] = 'Add to new courses';
 $string['addtorestoredcourses'] = 'Add to restored courses';
+$string['preservemanual'] = 'Manually added Users to autogroups are not removed when groups are automatically updated.';
 $string['defaults'] = 'Default Settings';
 $string['defaultroles'] = 'Default Eligible Roles';
 $string['enabled'] = 'Enabled';

--- a/settings.php
+++ b/settings.php
@@ -75,6 +75,14 @@ if ($hassiteconfig) {
             false
         )
     );
+    $settings->add(
+        new admin_setting_configcheckbox(
+            'local_autogroup/preservemanual',
+            get_string('preservemanual', 'local_autogroup'),
+            '',
+            1
+        )
+    );
 
     // default settings
     $settings->add(

--- a/version.php
+++ b/version.php
@@ -30,8 +30,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2018070300;
+$plugin->version = 2018102400;
 $plugin->requires = 2013111800.00;       // Requires this Moodle version (2.7).
-$plugin->release = '2.4';                // Plugin release.
+$plugin->release = '2.4.1';                // Plugin release.
 $plugin->component = 'local_autogroup';  // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Manually added Users to autogroup groups are not removed when groups are automatically updated.